### PR TITLE
fix: display event times in Swedish timezone on event cards

### DIFF
--- a/src/components/EventCard.astro
+++ b/src/components/EventCard.astro
@@ -19,6 +19,7 @@ try {
   formatted = new Intl.DateTimeFormat(lang === 'sv' ? 'sv-SE' : 'en-GB', {
     dateStyle: 'long',
     timeStyle: 'short',
+    timeZone: 'Europe/Stockholm',
   }).format(d);
 } catch {
   formatted = event.startDateTime;


### PR DESCRIPTION
UTC datetimes from the API were being rendered in server timezone (UTC). Added timeZone: 'Europe/Stockholm' to match the pattern already used on the event detail page.